### PR TITLE
feat: Enable real track suggestions, playback, and interactive chat

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-parcelize")
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity android:name=".activities.ChatActivity" />
         <activity android:name=".activities.MusicPlayerActivity" />
         <activity android:name=".activities.SuggestedTracksActivity" />
+        <activity android:name=".activities.PlaylistDetailsActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/myapp/activities/PlaylistDetailsActivity.kt
+++ b/app/src/main/java/com/example/myapp/activities/PlaylistDetailsActivity.kt
@@ -1,0 +1,118 @@
+package com.example.myapp.activities
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.example.myapp.R
+import com.example.myapp.adapters.PlaylistTrackAdapter
+import com.example.myapp.models.spotify_api.SpotifyTrackFull
+import com.example.myapp.utils.RetrofitClient
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+
+class PlaylistDetailsActivity : AppCompatActivity() {
+
+    private lateinit var playlistNameDetailsTextView: TextView
+    private lateinit var playlistOwnerDetailsTextView: TextView // Added for owner info
+    private lateinit var playlistImageDetailsView: ImageView
+    private lateinit var playlistTracksRecyclerView: RecyclerView
+    private lateinit var playlistTrackAdapter: PlaylistTrackAdapter
+
+    private var playlistId: String? = null
+    private var playlistName: String? = null
+    private var playlistImageUrl: String? = null
+    private var playlistOwner: String? = null // Added for owner info
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_playlist_details)
+
+        playlistNameDetailsTextView = findViewById(R.id.playlistNameDetailsTextView)
+        playlistOwnerDetailsTextView = findViewById(R.id.playlistOwnerDetailsTextView)
+        playlistImageDetailsView = findViewById(R.id.playlistImageDetailsView)
+        playlistTracksRecyclerView = findViewById(R.id.playlistTracksRecyclerView)
+
+        playlistId = intent.getStringExtra("PLAYLIST_ID")
+        playlistName = intent.getStringExtra("PLAYLIST_NAME")
+        playlistImageUrl = intent.getStringExtra("PLAYLIST_IMAGE_URL")
+        playlistOwner = intent.getStringExtra("PLAYLIST_OWNER_NAME") // Retrieve owner
+
+        playlistNameDetailsTextView.text = playlistName ?: "Playlist Details"
+        title = playlistName ?: "Playlist" // Set activity title
+        playlistOwnerDetailsTextView.text = "By ${playlistOwner ?: "Unknown Owner"}"
+
+
+        if (!playlistImageUrl.isNullOrEmpty()) {
+            playlistImageDetailsView.load(playlistImageUrl) {
+                placeholder(R.drawable.ic_album_placeholder)
+                error(R.drawable.ic_album_placeholder)
+            }
+        } else {
+            playlistImageDetailsView.setImageResource(R.drawable.ic_album_placeholder)
+        }
+
+        setupRecyclerView()
+
+        if (playlistId != null) {
+            fetchPlaylistTracks(playlistId!!)
+        } else {
+            Toast.makeText(this, "Playlist ID missing.", Toast.LENGTH_SHORT).show()
+            Log.e("PlaylistDetailsActivity", "Playlist ID is null.")
+        }
+    }
+
+    private fun setupRecyclerView() {
+        playlistTrackAdapter = PlaylistTrackAdapter(emptyList()) { track ->
+            val trackUri = track.uri
+            if (trackUri.isNullOrEmpty()) {
+                Toast.makeText(this, "Cannot play this track (missing URI)", Toast.LENGTH_SHORT).show()
+                return@PlaylistTrackAdapter
+            }
+            val intent = Intent(this, MusicPlayerActivity::class.java)
+            intent.putExtra("TRACK_URI_TO_PLAY", trackUri)
+            startActivity(intent)
+        }
+        playlistTracksRecyclerView.layoutManager = LinearLayoutManager(this)
+        playlistTracksRecyclerView.adapter = playlistTrackAdapter
+    }
+
+    private fun fetchPlaylistTracks(id: String) {
+        val sharedPreferences = getSharedPreferences("MyAppPrefs", Context.MODE_PRIVATE)
+        val spotifyToken = sharedPreferences.getString("spotify_access_token", null)
+
+        if (spotifyToken == null) {
+            Toast.makeText(this, "Spotify token not found. Please log in.", Toast.LENGTH_LONG).show()
+            // TODO: Redirect to LoginActivity or handle re-authentication
+            return
+        }
+
+        lifecycleScope.launch {
+            try {
+                val playlistTracksPagingObject = RetrofitClient.spotifyApiService.getPlaylistTracks("Bearer $spotifyToken", id)
+                val tracks = playlistTracksPagingObject.items.mapNotNull { it.track }
+                playlistTrackAdapter.updateData(tracks)
+                Log.d("PlaylistDetailsActivity", "Fetched ${tracks.size} tracks for playlist $id")
+            } catch (e: HttpException) {
+                Log.e("PlaylistDetailsActivity", "API Error: ${e.code()} ${e.message()}", e)
+                Toast.makeText(this@PlaylistDetailsActivity, "Error fetching playlist tracks: ${e.message()}", Toast.LENGTH_LONG).show()
+                if (e.code() == 401 || e.code() == 403) {
+                    // Token expired or invalid - potentially clear token and redirect to login
+                    Toast.makeText(this@PlaylistDetailsActivity, "Spotify token invalid. Please re-link.", Toast.LENGTH_LONG).show()
+                }
+            } catch (e: Exception) {
+                Log.e("PlaylistDetailsActivity", "Error fetching playlist tracks", e)
+                Toast.makeText(this@PlaylistDetailsActivity, "Could not fetch playlist tracks.", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapp/activities/SuggestedTracksActivity.kt
+++ b/app/src/main/java/com/example/myapp/activities/SuggestedTracksActivity.kt
@@ -1,20 +1,22 @@
 package com.example.myapp.activities
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.myapp.R
 import com.example.myapp.adapters.SuggestedTrackAdapter
-import com.example.myapp.adapters.SuggestedTrackDisplay
+import com.example.myapp.models.spotify_api.SpotifyTrackFull // Import the correct model
 
 class SuggestedTracksActivity : AppCompatActivity() {
 
     private lateinit var detectedMoodTextView: TextView
     private lateinit var suggestedTracksRecyclerView: RecyclerView
     private lateinit var suggestedTrackAdapter: SuggestedTrackAdapter
-    private var dummyTracks = mutableListOf<SuggestedTrackDisplay>()
+    private var suggestedTracksList = mutableListOf<SpotifyTrackFull>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,59 +28,25 @@ class SuggestedTracksActivity : AppCompatActivity() {
         val detectedMood = intent.getStringExtra("DETECTED_MOOD") ?: "Unknown Mood"
         detectedMoodTextView.text = "Songs for your $detectedMood mood:"
 
-        loadDummyTracksForMood(detectedMood)
+        val tracksFromIntent: ArrayList<SpotifyTrackFull>? = intent.getParcelableArrayListExtra("SUGGESTED_TRACKS")
 
-        suggestedTrackAdapter = SuggestedTrackAdapter(dummyTracks)
+        if (tracksFromIntent != null && tracksFromIntent.isNotEmpty()) {
+            suggestedTracksList.addAll(tracksFromIntent)
+        } else {
+            detectedMoodTextView.text = "No suggestions found for '$detectedMood', or an error occurred."
+        }
+
+        suggestedTrackAdapter = SuggestedTrackAdapter(suggestedTracksList) { track ->
+            val trackUri = track.uri
+            if (trackUri.isNullOrEmpty()) {
+                Toast.makeText(this, "Cannot play this track (missing URI)", Toast.LENGTH_SHORT).show()
+                return@SuggestedTrackAdapter
+            }
+            val intent = Intent(this, MusicPlayerActivity::class.java)
+            intent.putExtra("TRACK_URI_TO_PLAY", trackUri)
+            startActivity(intent)
+        }
         suggestedTracksRecyclerView.layoutManager = LinearLayoutManager(this)
         suggestedTracksRecyclerView.adapter = suggestedTrackAdapter
-    }
-
-    private fun loadDummyTracksForMood(mood: String) {
-        dummyTracks.clear()
-        when (mood.lowercase()) {
-            "happy" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Walking on Sunshine", "Katrina & The Waves"))
-                dummyTracks.add(SuggestedTrackDisplay("Good Day Sunshine", "The Beatles"))
-                dummyTracks.add(SuggestedTrackDisplay("Happy", "Pharrell Williams"))
-            }
-            "sad" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Hallelujah", "Leonard Cohen"))
-                dummyTracks.add(SuggestedTrackDisplay("Mad World", "Gary Jules"))
-                dummyTracks.add(SuggestedTrackDisplay("Fix You", "Coldplay"))
-            }
-            "energetic", "workout" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Eye of the Tiger", "Survivor"))
-                dummyTracks.add(SuggestedTrackDisplay("Can't Stop the Feeling!", "Justin Timberlake"))
-                dummyTracks.add(SuggestedTrackDisplay("Don't Stop Me Now", "Queen"))
-            }
-            "chill", "relaxed", "calm" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Weightless", "Marconi Union"))
-                dummyTracks.add(SuggestedTrackDisplay("Teardrop", "Massive Attack"))
-                dummyTracks.add(SuggestedTrackDisplay("Better Together", "Jack Johnson"))
-            }
-            "rock" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Bohemian Rhapsody", "Queen"))
-                dummyTracks.add(SuggestedTrackDisplay("Stairway to Heaven", "Led Zeppelin"))
-            }
-            "pop" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Blinding Lights", "The Weeknd"))
-                dummyTracks.add(SuggestedTrackDisplay("Shape of You", "Ed Sheeran"))
-            }
-            "electronic" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Strobe", "deadmau5"))
-                dummyTracks.add(SuggestedTrackDisplay("Around the World", "Daft Punk"))
-            }
-            "classical" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Für Elise", "Beethoven"))
-                dummyTracks.add(SuggestedTrackDisplay("Clair de Lune", "Debussy"))
-            }
-            "focus", "study" -> {
-                dummyTracks.add(SuggestedTrackDisplay("Ambient 1: Music for Airports", "Brian Eno"))
-                dummyTracks.add(SuggestedTrackDisplay("Nuvole Bianche", "Ludovico Einaudi"))
-            }
-            else -> {
-                dummyTracks.add(SuggestedTrackDisplay("No specific tracks for this mood yet.", "System"))
-            }
-        }
     }
 }

--- a/app/src/main/java/com/example/myapp/adapters/PlaylistAdapter.kt
+++ b/app/src/main/java/com/example/myapp/adapters/PlaylistAdapter.kt
@@ -41,11 +41,11 @@ class PlaylistAdapter(
             playlistNameTextView.text = playlist.name
             if (playlist.images.isNotEmpty()) {
                 playlistImageView.load(playlist.images[0].url) {
-                    placeholder(R.drawable.ic_album_placeholder) // Placeholder while loading
-                    error(R.drawable.ic_album_placeholder) // Placeholder on error
+                    placeholder(R.drawable.ic_album_placeholder)
+                    error(R.drawable.ic_album_placeholder)
                 }
             } else {
-                playlistImageView.load(R.drawable.ic_album_placeholder)
+                playlistImageView.setImageResource(R.drawable.ic_album_placeholder) // Use setImageResource for local drawables
             }
             itemView.setOnClickListener { onItemClicked(playlist) }
         }

--- a/app/src/main/java/com/example/myapp/adapters/PlaylistTrackAdapter.kt
+++ b/app/src/main/java/com/example/myapp/adapters/PlaylistTrackAdapter.kt
@@ -1,0 +1,65 @@
+package com.example.myapp.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.example.myapp.R
+import com.example.myapp.models.spotify_api.SpotifyTrackFull
+import java.util.concurrent.TimeUnit
+
+class PlaylistTrackAdapter(
+    private var tracks: List<SpotifyTrackFull>,
+    private val onItemClicked: (SpotifyTrackFull) -> Unit
+) : RecyclerView.Adapter<PlaylistTrackAdapter.PlaylistTrackViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlaylistTrackViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_playlist_track, parent, false)
+        return PlaylistTrackViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: PlaylistTrackViewHolder, position: Int) {
+        val track = tracks[position]
+        holder.bind(track, onItemClicked)
+    }
+
+    override fun getItemCount(): Int = tracks.size
+
+    fun updateData(newTracks: List<SpotifyTrackFull>) {
+        tracks = newTracks
+        notifyDataSetChanged()
+    }
+
+    class PlaylistTrackViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val albumArtImageView: ImageView = itemView.findViewById(R.id.playlistTrackAlbumArtImageView)
+        private val trackNameTextView: TextView = itemView.findViewById(R.id.playlistTrackNameTextView)
+        private val artistTextView: TextView = itemView.findViewById(R.id.playlistTrackArtistTextView)
+        private val durationTextView: TextView = itemView.findViewById(R.id.playlistTrackDurationTextView)
+
+        fun bind(track: SpotifyTrackFull, onItemClicked: (SpotifyTrackFull) -> Unit) {
+            trackNameTextView.text = track.name
+            val artistAlbumText = "${track.artists.joinToString { it.name }} - ${track.album.name}"
+            artistTextView.text = artistAlbumText
+
+            if (track.album.images.isNotEmpty()) {
+                albumArtImageView.load(track.album.images[0].url) {
+                    placeholder(R.drawable.ic_album_placeholder)
+                    error(R.drawable.ic_album_placeholder)
+                }
+            } else {
+                albumArtImageView.load(R.drawable.ic_album_placeholder)
+            }
+
+            // Format duration from ms to M:SS
+            val minutes = TimeUnit.MILLISECONDS.toMinutes(track.duration_ms.toLong())
+            val seconds = TimeUnit.MILLISECONDS.toSeconds(track.duration_ms.toLong()) % 60
+            durationTextView.text = String.format("%d:%02d", minutes, seconds)
+
+            itemView.setOnClickListener { onItemClicked(track) }
+        }
+    }
+}

--- a/app/src/main/java/com/example/myapp/adapters/SuggestedTrackAdapter.kt
+++ b/app/src/main/java/com/example/myapp/adapters/SuggestedTrackAdapter.kt
@@ -6,11 +6,11 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.example.myapp.R
-
-data class SuggestedTrackDisplay(val title: String, val artist: String)
+import com.example.myapp.models.spotify_api.SpotifyTrackFull // Import the correct model
 
 class SuggestedTrackAdapter(
-    private var tracks: List<SuggestedTrackDisplay>
+    private var tracks: List<SpotifyTrackFull>, // Use SpotifyTrackFull
+    private val onItemClicked: (SpotifyTrackFull) -> Unit // Click listener lambda
 ) : RecyclerView.Adapter<SuggestedTrackAdapter.SuggestedTrackViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SuggestedTrackViewHolder {
@@ -21,12 +21,12 @@ class SuggestedTrackAdapter(
 
     override fun onBindViewHolder(holder: SuggestedTrackViewHolder, position: Int) {
         val track = tracks[position]
-        holder.bind(track)
+        holder.bind(track, onItemClicked) // Pass the click listener to bind
     }
 
     override fun getItemCount(): Int = tracks.size
 
-    fun updateData(newTracks: List<SuggestedTrackDisplay>) {
+    fun updateData(newTracks: List<SpotifyTrackFull>) {
         tracks = newTracks
         notifyDataSetChanged()
     }
@@ -35,10 +35,10 @@ class SuggestedTrackAdapter(
         private val trackNameTextView: TextView = itemView.findViewById(R.id.suggestedTrackNameTextView)
         private val trackArtistTextView: TextView = itemView.findViewById(R.id.suggestedTrackArtistTextView)
 
-        fun bind(track: SuggestedTrackDisplay) {
-            trackNameTextView.text = track.title
-            trackArtistTextView.text = track.artist
-            // itemView.setOnClickListener { onItemClicked(track) } // Can add click listener if needed
+        fun bind(track: SpotifyTrackFull, onItemClicked: (SpotifyTrackFull) -> Unit) { // Bind SpotifyTrackFull
+            trackNameTextView.text = track.name
+            trackArtistTextView.text = track.artists.joinToString(", ") { it.name }
+            itemView.setOnClickListener { onItemClicked(track) } // Set the click listener on the item view
         }
     }
 }

--- a/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyAlbumSimple.kt
+++ b/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyAlbumSimple.kt
@@ -1,6 +1,10 @@
 package com.example.myapp.models.spotify_api
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 // Represents a simplified album object as returned by various Spotify API endpoints
+@Parcelize
 data class SpotifyAlbumSimple(
     val id: String,
     val name: String,
@@ -12,4 +16,4 @@ data class SpotifyAlbumSimple(
     val release_date_precision: String?
     // external_urls: Map<String, String>?,
     // href: String? // Link to the full album object
-)
+) : Parcelable

--- a/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyArtistSimple.kt
+++ b/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyArtistSimple.kt
@@ -1,10 +1,14 @@
 package com.example.myapp.models.spotify_api
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 // Represents a simplified artist object as returned by various Spotify API endpoints
+@Parcelize
 data class SpotifyArtistSimple(
     val id: String,
     val name: String,
     val uri: String,
-    val external_urls: Map<String, String>? // e.g., {"spotify": "https://open.spotify.com/artist/..."}
+    val external_urls: Map<String, String>? = null // e.g., {"spotify": "https://open.spotify.com/artist/..."}
     // href: String? // Link to the full artist object
-)
+) : Parcelable

--- a/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyImage.kt
+++ b/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyImage.kt
@@ -1,7 +1,11 @@
 package com.example.myapp.models.spotify_api
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class SpotifyImage(
     val url: String,
     val height: Int?,
     val width: Int?
-)
+) : Parcelable

--- a/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyPlaylistTrack.kt
+++ b/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyPlaylistTrack.kt
@@ -1,0 +1,30 @@
+package com.example.myapp.models.spotify_api
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+// Represents an item in a playlist, which contains track information.
+// Note: Spotify API's Get Playlist Items endpoint returns a paging object of these.
+@Parcelize
+data class SpotifyPlaylistTrack(
+    // val added_at: String?, // Timestamp when the track was added. Optional.
+    // val added_by: SpotifyUser?, // User who added the track. Optional. Requires SpotifyUser to be Parcelable.
+    // val is_local: Boolean, // Whether the track is a local file or not.
+    val track: SpotifyTrackFull? // The track information. Can be null if track is unavailable (e.g. deleted).
+    // val primary_color: String? // Not typically used for playback.
+    // val video_thumbnail: VideoThumbnail? // Not typically used for playback.
+) : Parcelable
+
+// Example if you needed added_by with a simplified user object that's also Parcelable
+// @Parcelize
+// data class SpotifyPlaylistTrackAdder(
+//    val id: String,
+//    val type: String, // "user"
+//    val uri: String
+// ) : Parcelable
+
+// Example for video_thumbnail if needed
+// @Parcelize
+// data class VideoThumbnail(
+//    val url: String?
+// ) : Parcelable

--- a/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyTrackFull.kt
+++ b/app/src/main/java/com/example/myapp/models/spotify_api/SpotifyTrackFull.kt
@@ -1,6 +1,10 @@
 package com.example.myapp.models.spotify_api
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 // Represents a full track object as returned by Spotify API (e.g., in Saved Tracks)
+@Parcelize
 data class SpotifyTrackFull(
     val id: String,
     val name: String,
@@ -13,8 +17,8 @@ data class SpotifyTrackFull(
     val preview_url: String?,
     val track_number: Int?,
     val disc_number: Int?,
-    val external_urls: Map<String, String>?
+    val external_urls: Map<String, String>? = null
     // available_markets: List<String>?
     // external_ids: Map<String, String>? // e.g., {"isrc": "..."}
     // is_local: Boolean
-)
+) : Parcelable

--- a/app/src/main/java/com/example/myapp/services/SpotifyApiService.kt
+++ b/app/src/main/java/com/example/myapp/services/SpotifyApiService.kt
@@ -24,4 +24,13 @@ interface SpotifyApiService {
         @Query("limit") limit: Int = 20,
         @Query("offset") offset: Int = 0
     ): SpotifyPagingObject<com.example.myapp.models.spotify_api.SpotifySavedTrack> // Fully qualify for clarity
+
+    @GET("v1/playlists/{playlist_id}/tracks")
+    suspend fun getPlaylistTracks(
+        @Header("Authorization") token: String,
+        @Path("playlist_id") playlistId: String,
+        @Query("fields") fields: String = "items(track(id,name,uri,duration_ms,explicit,album(name,images,artists(name)),artists(id,name)))", // More detailed fields
+        @Query("limit") limit: Int = 50,
+        @Query("offset") offset: Int = 0
+    ): SpotifyPagingObject<com.example.myapp.models.spotify_api.SpotifyPlaylistTrack>
 }

--- a/app/src/main/java/com/example/myapp/utils/UserMusicCache.kt
+++ b/app/src/main/java/com/example/myapp/utils/UserMusicCache.kt
@@ -1,0 +1,24 @@
+package com.example.myapp.utils
+
+import com.example.myapp.models.spotify_api.SpotifyPlaylistSimple
+import com.example.myapp.models.spotify_api.SpotifyTrackFull
+
+object UserMusicCache {
+    val userPlaylists = mutableListOf<SpotifyPlaylistSimple>()
+    val userSavedTracks = mutableListOf<SpotifyTrackFull>()
+
+    fun setPlaylists(playlists: List<SpotifyPlaylistSimple>) {
+        userPlaylists.clear()
+        userPlaylists.addAll(playlists)
+    }
+
+    fun setSavedTracks(tracks: List<SpotifyTrackFull>) {
+        userSavedTracks.clear()
+        userSavedTracks.addAll(tracks)
+    }
+
+    fun clearCache() {
+        userPlaylists.clear()
+        userSavedTracks.clear()
+    }
+}

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -40,4 +40,35 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/messageEditText" />
 
+    <LinearLayout
+        android:id="@+id/moodConfirmationLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:visibility="gone"
+        tools:visibility="visible"
+        android:gravity="center"
+        android:paddingTop="4dp"
+        android:paddingBottom="4dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/messageEditText" >
+
+        <Button
+            android:id="@+id/yesMoodButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Yes, that's right!"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_marginEnd="8dp"/>
+
+        <Button
+            android:id="@+id/noMoodButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="No, try again"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_marginStart="8dp"/>
+    </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_playlist_details.xml
+++ b/app/src/main/res/layout/activity_playlist_details.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.PlaylistDetailsActivity">
+
+    <ImageView
+        android:id="@+id/playlistImageDetailsView"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:scaleType="centerCrop"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@drawable/ic_album_placeholder"
+        android:contentDescription="Playlist Cover Art"/>
+
+    <TextView
+        android:id="@+id/playlistNameDetailsTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/playlistImageDetailsView"
+        app:layout_constraintTop_toTopOf="@+id/playlistImageDetailsView"
+        tools:text="Playlist Name" />
+
+    <TextView
+        android:id="@+id/playlistOwnerDetailsTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/playlistNameDetailsTextView"
+        app:layout_constraintStart_toStartOf="@id/playlistNameDetailsTextView"
+        app:layout_constraintEnd_toEndOf="@id/playlistNameDetailsTextView"
+        android:layout_marginTop="4dp"
+        tools:text="By Playlist Owner"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"/>
+
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/playlistTracksRecyclerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/playlistImageDetailsView"
+        tools:listitem="@layout/item_playlist_track" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_playlist_track.xml
+++ b/app/src/main/res/layout/item_playlist_track.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:padding="12dp"
+    android:gravity="center_vertical"
+    android:background="?android:attr/selectableItemBackground">
+
+    <ImageView
+        android:id="@+id/playlistTrackAlbumArtImageView"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:scaleType="centerCrop"
+        tools:src="@drawable/ic_album_placeholder"
+        android:contentDescription="Track Album Art"
+        android:layout_marginEnd="12dp"/>
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/playlistTrackNameTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Track Name In Playlist"
+            android:textAppearance="?attr/textAppearanceListItem"
+            android:textSize="16sp"
+            android:maxLines="1"
+            android:ellipsize="end"/>
+
+        <TextView
+            android:id="@+id/playlistTrackArtistTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Artist Name - Album Name"
+            android:textAppearance="?attr/textAppearanceListItemSecondary"
+            android:textSize="14sp"
+            android:maxLines="1"
+            android:ellipsize="end"/>
+    </LinearLayout>
+
+    <!-- Optional: Duration TextView or Play Button per track -->
+    <TextView
+        android:id="@+id/playlistTrackDurationTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="3:45"
+        android:textSize="12sp"
+        android:layout_marginStart="8dp"/>
+
+</LinearLayout>


### PR DESCRIPTION
This commit significantly enhances the application by:

- Integrating Real Track Data into Suggestions:
  - SuggestedTracksActivity now displays actual tracks filtered from your saved library based on the mood detected in ChatActivity.
  - Implemented UserMusicCache and made relevant Spotify models Parcelable.

- Enabling Widespread Playback Control:
  - Tracks selected from SuggestedTracksActivity now play in MusicPlayerActivity.
  - Tracks selected from the "Saved Tracks" list in MainActivity now play.
  - Playlists in MainActivity open a new PlaylistDetailsActivity, which lists tracks from that playlist. These tracks can then be selected for playback.

- Enhancing Music Player UI:
  - MusicPlayerActivity now displays the album art of the currently playing track using the Spotify ImagesApi.

- Improving Chat Interaction:
  - Added a confirmation step in ChatActivity after mood detection. You can confirm ("Yes") or deny ("No") the bot's understanding, influencing whether track suggestions are shown.