### PR TITLE
fix: Configure project for AndroidX compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+# AndroidX and Jetifier flags
+android.useAndroidX=true
+android.enableJetifier=true
+
+# Other common properties (can be added as needed)
+# org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# android.enableR8=true
+# android.nonTransitiveRClass=true
+# kotlin.code.style=official
+# org.gradle.configureondemand=true
+# org.gradle.parallel=true
+# org.gradle.caching=true
+# org.gradle.daemon=true
+# kapt.incremental.apt=true


### PR DESCRIPTION
I created and configured the `gradle.properties` file to enable AndroidX and Jetifier. This should resolve build issues related to AndroidX dependencies not being recognized.

I added the following properties:
- android.useAndroidX=true
- android.enableJetifier=true

A full verification build could not be completed due to intermittent network issues preventing Gradle distribution download, but this change directly addresses the reported AndroidX configuration errors.